### PR TITLE
Anleitung zur CJK-Unterstützung in README und Compose-Dateien hinzufügen

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ docker compose up -d
 
 ---
 
+## Optional: CJK Font Support
+
+If you need support for Chinese, Japanese, or Korean (CJK) characters in your Anki cards, you can enable this by uncommenting the following environment variables in the `docker-compose.yml` file:
+
+```yaml
+environment:
+  - PUID=1000
+  - PGID=1000
+  # Uncomment the following lines to enable CJK font support
+  - DOCKER_MODS=linuxserver/mods:universal-package-install
+  - INSTALL_PACKAGES=language-pack-zh-hans|fonts-arphic-ukai|fonts-arphic-uming|fonts-ipafont-mincho|fonts-ipafont-gothic|fonts-unfonts-core
+```
+
+After making these changes, rebuild your container for the changes to take effect.
+
 ## AnkiConnect Configuration
 
 If you want to expose the Anki client to http requests, make sure to install the [AnkiConnect](https://ankiweb.net/shared/info/2055492159) Add-on and to configure the Add-on with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
+      # Uncomment the following lines to enable CJK font support
+      # - DOCKER_MODS=linuxserver/mods:universal-package-install
+      # - INSTALL_PACKAGES=language-pack-zh-hans|fonts-arphic-ukai|fonts-arphic-uming|fonts-ipafont-mincho|fonts-ipafont-gothic|fonts-unfonts-core
     volumes:
       - ./anki_data:/config
     ports:


### PR DESCRIPTION
Hallo, ich bin ein Chinese und lerne Deutsch. Ich habe Ihr Image gefunden. Es ist sehr gut.

Habe ich gesehen: Standardmäßig unterstüzt es kein CJK (Chinesisch, Japanisch, und Koreanisch). Nach einer Scuhe habe ich dntdeckt: Mit zwei Umgebungsvariablen kann man CJK aktiverien.

Vielleicht brauchen auch andere Leute CJK. Darum möchte ich die Schritte zu Ihrem Code hinzufügen. So können andere es leichter benutzen.

Bitte sehen Sie den Screenshot vor und nach dem Hinzufügen dieser zwei Umgebungsvariablen an:
- Kein CJK:
<img width="1851" height="904" alt="image" src="https://github.com/user-attachments/assets/45d4c113-ca93-4429-bb6c-1ef94e7038c2" />

- CJK:
<img width="1844" height="902" alt="image" src="https://github.com/user-attachments/assets/e89492e9-84e5-4550-afde-11a51cd1ebab" />
