### PR TITLE
fix(config): update anki executable path

### DIFF
--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -3,7 +3,7 @@
     <menu id="root-menu" label="MENU">
         <item label="Anki">
             <action name="Execute">
-                <command>/usr/bin/anki</command>
+                <command>/usr/local/bin/anki</command>
             </action>
         </item>
         <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm">


### PR DESCRIPTION
- Change anki command path from /usr/bin/anki to /usr/local/bin/anki

**Description:**

I encountered an issue with the desktop environment when the Anki executable path is misconfigured.

**Problem:**

When right-clicking on the desktop and selecting "Anki" from the context menu, I get an error message indicating that the executable file cannot be found.

**Root Cause:**
The actual Anki installation path is `/usr/local/bin/anki`, but the desktop menu entry was pointing to an incorrect path.

Environment:
- Using anki-launcher version 25.07.5
- Running in Docker container based on lsiobase/kasmvnc:ubuntunoble
- Anki installed via the official launcher from GitHub releases
