### PR TITLE
feat(docker): add mplayer dependencies for audio playback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && \
         libxcb-xinerama0 \
         libxcb-cursor0 \
         python3-xdg \
+		mplayer \
+		mplayer-gui \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Add mplayer and mplayer-gui packages to support audio functionality
- Required for Anki audio playback in Docker environment

Installed this locally and confirmed that audio on the affected Anki cards now plays without errors.